### PR TITLE
Fixed ./make

### DIFF
--- a/make
+++ b/make
@@ -25,7 +25,8 @@ fi
 rock $OOC_FLAGS -libfolder=$ROCK_DIST/sdk -dynamiclib=$LIBDIR/librock-sdk.so || exit 1
 
 echo "Compiling oc (core)"
-rock $OOC_FLAGS -libfolder=source/core -dynamiclib=$LIBDIR/liboc-core.so +-DBUILD_DATE="\"$(date '+%Y-%m-%d at %H:%M')\"" || exit 2
+BUILD_DATE="\"$(date '+%Y-%m-%d at %H:%M')\""
+rock $OOC_FLAGS -libfolder=source/core -dynamiclib=$LIBDIR/liboc-core.so +-DBUILD_DATE="$(BUILD_DATE)" || exit 2
 
 echo "Compiling oc (launcher)"
 rock $OOC_FLAGS -sourcepath=source -packagefilter=launcher launcher/main -L$LIBDIR -gc=dynamic -lrock-sdk -loc-core -lnagaqueen -o=bin/oc $OOC_FLAGS || exit 3


### PR DESCRIPTION
`./make` exploded all over it's place on my system.
This (tiny) change fixes it :)
